### PR TITLE
Add semver bump automation

### DIFF
--- a/.github/workflows/semver-bump.yml
+++ b/.github/workflows/semver-bump.yml
@@ -54,18 +54,6 @@ jobs:
           )
           echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
           npm version "$new_version" --no-git-tag-version
-          node - <<'NODE'
-          const fs = require('fs')
-          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'))
-          const version = pkg.version
-          const badge = `![Version](https://img.shields.io/badge/version-${version}-blue)`
-          const readme = fs.readFileSync('README.md', 'utf8')
-          const next = readme.replace(
-            /!\[Version\]\(https:\/\/img\.shields\.io\/badge\/version-[^)]+\)/,
-            badge
-          )
-          fs.writeFileSync('README.md', next)
-          NODE
         env:
           BUMP: ${{ steps.bump.outputs.bump }}
 
@@ -77,6 +65,6 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json README.md
+          git add package.json package-lock.json
           git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }}"
           git push

--- a/.github/workflows/semver-bump.yml
+++ b/.github/workflows/semver-bump.yml
@@ -1,0 +1,82 @@
+name: Semver Bump
+
+on:
+  pull_request:
+    branches: [master]
+    types: [closed]
+
+jobs:
+  bump:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Determine bump
+        id: bump
+        run: |
+          labels=$(jq -r '.pull_request.labels[].name' "$GITHUB_EVENT_PATH" | tr '\n' ' ')
+          bump="patch"
+          if echo "$labels" | grep -q "semver:major"; then
+            bump="major"
+          elif echo "$labels" | grep -q "semver:minor"; then
+            bump="minor"
+          elif echo "$labels" | grep -q "semver:patch"; then
+            bump="patch"
+          fi
+          echo "bump=$bump" >> "$GITHUB_OUTPUT"
+
+      - name: Bump version files
+        id: version
+        run: |
+          new_version=$(node - <<'NODE'
+          const fs = require('fs')
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+          const bump = process.env.BUMP
+          const [major, minor, patch] = pkg.version.split('.').map(Number)
+          let next = [major, minor, patch]
+          if (bump === 'major') next = [major + 1, 0, 0]
+          if (bump === 'minor') next = [major, minor + 1, 0]
+          if (bump === 'patch') next = [major, minor, patch + 1]
+          process.stdout.write(next.join('.'))
+          NODE
+          )
+          echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
+          npm version "$new_version" --no-git-tag-version
+          node - <<'NODE'
+          const fs = require('fs')
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+          const version = pkg.version
+          const badge = `![Version](https://img.shields.io/badge/version-${version}-blue)`
+          const readme = fs.readFileSync('README.md', 'utf8')
+          const next = readme.replace(
+            /!\[Version\]\(https:\/\/img\.shields\.io\/badge\/version-[^)]+\)/,
+            badge
+          )
+          fs.writeFileSync('README.md', next)
+          NODE
+        env:
+          BUMP: ${{ steps.bump.outputs.bump }}
+
+      - name: Commit and push
+        run: |
+          if git diff --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json README.md
+          git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }}"
+          git push

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Banana Tracker
 
-![Version](https://img.shields.io/badge/version-1.0.0-blue)
+![Version](https://img.shields.io/github/package-json/v/travishuff/accounting-tracker?label=version)
 
 A React 19 inventory and reporting app for tracking banana purchases, sales, and
 margin scenarios.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Banana Tracker
 
+![Version](https://img.shields.io/badge/version-1.0.0-blue)
+
 A React 19 inventory and reporting app for tracking banana purchases, sales, and
 margin scenarios.
 
@@ -35,6 +37,14 @@ the scripts:
 - `npm run lint`
 - `npm run format:check`
 - `npm run typecheck`
+
+## Versioning
+
+Every merged PR bumps the version automatically based on labels:
+
+- `semver:major`
+- `semver:minor`
+- `semver:patch` (default if no semver label is applied)
 
 ## API Configuration
 


### PR DESCRIPTION
## Summary
- add a workflow that bumps the package version after merged PRs based on semver labels
- add a README version badge and document semver label usage

## Testing
- not run (workflow/readme changes only)