### PR TITLE
Force GitHub Actions Node 24

### DIFF
--- a/.github/workflows/semver-bump.yml
+++ b/.github/workflows/semver-bump.yml
@@ -9,6 +9,8 @@ jobs:
   bump:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       contents: write
       pull-requests: read


### PR DESCRIPTION
## Summary
- opt semver bump workflow into Node.js 24 for JavaScript actions

## Testing
- not run (workflow-only change)