### PR TITLE
Snap stale month defaults forward and surface empty-range hint on Analytics

### DIFF
--- a/src/Analytics.tsx
+++ b/src/Analytics.tsx
@@ -1,4 +1,5 @@
 import { Link, useLoaderData } from 'react-router'
+import { useEffect } from 'react'
 import type { ChangeEvent } from 'react'
 
 import './css/analytics.css'
@@ -13,7 +14,11 @@ import {
   getUnsoldExpiredBananas,
   getUnsoldUnexpiredBananas,
 } from './lib/bananaUtils'
-import { endOfCurrentMonth, startOfCurrentMonth } from './lib/date'
+import {
+  endOfCurrentMonth,
+  isStaleMonthDefault,
+  startOfCurrentMonth,
+} from './lib/date'
 import type { Banana } from './types'
 
 type AnalyticsSettings = {
@@ -36,6 +41,18 @@ const Analytics = () => {
     'banana-tracker.analytics',
     DEFAULT_ANALYTICS_SETTINGS
   )
+
+  useEffect(() => {
+    if (isStaleMonthDefault(settings.start, settings.end)) {
+      setSettings((current) => ({
+        ...current,
+        end: endOfCurrentMonth(),
+        start: startOfCurrentMonth(),
+      }))
+    }
+    // Snap forward once on mount; later edits are intentional and should stick.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const scopedBananas = getBananasByTime(bananas, settings.start, settings.end)
   const soldBananas = getSoldBananas(scopedBananas)
@@ -100,6 +117,13 @@ const Analytics = () => {
           handleDateChange={handleDateChange}
           start={settings.start}
         />
+        {bananas.length > 0 && scopedBananas.length === 0 ? (
+          <div className="alert alert-info" role="status">
+            No bananas fall inside the selected date range. {bananas.length}{' '}
+            banana{bananas.length === 1 ? '' : 's'} sit outside it — adjust the
+            dates above or use Reset All Fields to jump back to this month.
+          </div>
+        ) : null}
       </section>
 
       <section className="card stack">

--- a/src/__tests__/Analytics.test.tsx
+++ b/src/__tests__/Analytics.test.tsx
@@ -70,4 +70,135 @@ describe('Analytics', () => {
       })
     )
   })
+
+  test('snaps a stale prior-month default range forward to the current month', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date(2026, 4, 12))
+
+    window.localStorage.setItem(
+      'banana-tracker.analytics',
+      JSON.stringify({
+        buyPrice: 0.2,
+        end: '2026-03-31',
+        sellPrice: 0.35,
+        start: '2026-03-01',
+      })
+    )
+
+    try {
+      render(
+        <MemoryRouter>
+          <Analytics />
+        </MemoryRouter>
+      )
+
+      const startInput = (await screen.findByLabelText(
+        /start date/i
+      )) as HTMLInputElement
+      const endInput = screen.getByLabelText(/end date/i) as HTMLInputElement
+
+      expect(startInput.value).toBe('2026-05-01')
+      expect(endInput.value).toBe('2026-05-31')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('does not snap a user-chosen range that is not a full prior month', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date(2026, 4, 12))
+
+    window.localStorage.setItem(
+      'banana-tracker.analytics',
+      JSON.stringify({
+        buyPrice: 0.2,
+        end: '2026-03-15',
+        sellPrice: 0.35,
+        start: '2026-03-05',
+      })
+    )
+
+    try {
+      render(
+        <MemoryRouter>
+          <Analytics />
+        </MemoryRouter>
+      )
+
+      const startInput = (await screen.findByLabelText(
+        /start date/i
+      )) as HTMLInputElement
+      const endInput = screen.getByLabelText(/end date/i) as HTMLInputElement
+
+      expect(startInput.value).toBe('2026-03-05')
+      expect(endInput.value).toBe('2026-03-15')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('shows a hint when loader returned bananas but the date filter drops them all', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date(2026, 4, 12))
+
+    // Pin a range that contains none of the test bananas (which are dated 2026-03-*),
+    // using a non-month-boundary so the snap-forward logic does not fire.
+    window.localStorage.setItem(
+      'banana-tracker.analytics',
+      JSON.stringify({
+        buyPrice: 0.2,
+        end: '2026-05-12',
+        sellPrice: 0.35,
+        start: '2026-05-02',
+      })
+    )
+
+    try {
+      render(
+        <MemoryRouter>
+          <Analytics />
+        </MemoryRouter>
+      )
+
+      expect(
+        await screen.findByText(/no bananas fall inside the selected date range/i)
+      ).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('does not show the empty-range hint when at least one banana matches', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date(2026, 2, 15))
+
+    // Pin a range that contains the test bananas; the module-level defaults
+    // were computed at real import time and won't match the fake clock.
+    window.localStorage.setItem(
+      'banana-tracker.analytics',
+      JSON.stringify({
+        buyPrice: 0.2,
+        end: '2026-03-31',
+        sellPrice: 0.35,
+        start: '2026-03-01',
+      })
+    )
+
+    try {
+      render(
+        <MemoryRouter>
+          <Analytics />
+        </MemoryRouter>
+      )
+
+      // Wait for any effects to settle so a late-rendered hint would be caught.
+      await screen.findByRole('heading', { name: /analytics/i })
+
+      expect(
+        screen.queryByText(/no bananas fall inside the selected date range/i)
+      ).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -199,6 +199,11 @@ input {
   color: #8a2b2b;
 }
 
+.alert-info {
+  background: rgba(63, 132, 199, 0.12);
+  color: #1c4a7a;
+}
+
 .info-strip {
   justify-content: space-between;
   padding: 0.85rem 1rem;

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -51,3 +51,17 @@ export const isExpiredOn = (
   buyDate: string,
   referenceDate: string = getTodayDate()
 ) => differenceInCalendarDays(referenceDate, buyDate) > BANANA_SHELF_LIFE_DAYS
+
+export const isStaleMonthDefault = (
+  start: string,
+  end: string,
+  today: string = getTodayDate()
+) => {
+  const [year, month] = start.split('-').map(Number)
+  if (!year || !month) {
+    return false
+  }
+  const firstDay = formatDateInput(new Date(year, month - 1, 1))
+  const lastDay = formatDateInput(new Date(year, month, 0))
+  return start === firstDay && end === lastDay && end < today
+}


### PR DESCRIPTION
## Summary

Two small UX fixes for the Analytics page. Surfaced after the backend ([accounting-tracker-backend#4](https://github.com/travishuff/accounting-tracker-backend/pull/4)) stopped wiping its database on startup, which exposed an existing failure mode: the Analytics date range is persisted in `localStorage`, so on month-rollover the stale saved defaults silently drop all current-month bananas out of scope and the page looks broken.

- **Auto-snap stale full-month defaults forward.** On mount, if the stored range is a *full calendar month that has already ended* (start is the 1st of some month, end is the last day of that same month, end is before today), snap it to the current month. The "full calendar month" guard means a user-chosen historical view like `2026-03-05 → 2026-03-15` is not clobbered. New `isStaleMonthDefault` helper in [src/lib/date.ts](src/lib/date.ts) covers the check.
- **Empty-range hint on Analytics.** When the loader returned bananas but the date filter drops them all, render a small `alert-info` banner below the date controls. Points at the range as the cause and at the existing **Reset All Fields** button as the cure. Avoids the failure mode where the page looks empty and the user blames the backend. Adds a `.alert-info` variant alongside the existing `.alert-success` / `.alert-error` styles.

## Test plan

- [x] `npx vitest run` — 24/24 pass, including 4 new Analytics tests
- [x] `npx eslint src/` clean
- [x] `npx tsc --noEmit` clean
- [ ] Manual: set Analytics range to a past full month (e.g. last month), hard-refresh — it should snap back to this month
- [ ] Manual: set range to a non-month historical window (e.g. `2026-03-05 → 2026-03-15`), refresh — should stick, and if no bananas fall in range, the hint should render

## Reviewer notes

- The snap fires once per mount via a `useEffect` with `[]` deps and an `eslint-disable react-hooks/exhaustive-deps` line — intentional, so later in-session edits to the dates aren't fought by the effect.
- Tests use `vi.useFakeTimers({ toFake: ['Date'] })` rather than the default — the default fakes `setTimeout`/`setInterval` too, which deadlocks testing-library's polling helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)