### PR TITLE
Connect analytics reset to backend

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 .obsidian/
+.claude/
 .github/
 coverage/
 dist/

--- a/src/Analytics.tsx
+++ b/src/Analytics.tsx
@@ -1,11 +1,12 @@
-import { Link, useLoaderData } from 'react-router'
-import { useEffect } from 'react'
+import { Link, useLoaderData, useRevalidator } from 'react-router'
+import { useEffect, useState } from 'react'
 import type { ChangeEvent } from 'react'
 
 import './css/analytics.css'
 
 import Dates from './Dates'
 import Margins from './Margins'
+import { resetDatabase } from './api/bananas'
 import useLocalStorageState from './hooks/useLocalStorageState'
 import {
   formatCurrency,
@@ -28,6 +29,11 @@ type AnalyticsSettings = {
   start: string
 }
 
+type Feedback = {
+  message: string
+  type: 'error' | 'success'
+}
+
 const DEFAULT_ANALYTICS_SETTINGS: AnalyticsSettings = {
   buyPrice: 0.2,
   end: endOfCurrentMonth(),
@@ -37,10 +43,13 @@ const DEFAULT_ANALYTICS_SETTINGS: AnalyticsSettings = {
 
 const Analytics = () => {
   const bananas = useLoaderData<Banana[]>()
+  const revalidator = useRevalidator()
   const [settings, setSettings] = useLocalStorageState<AnalyticsSettings>(
     'banana-tracker.analytics',
     DEFAULT_ANALYTICS_SETTINGS
   )
+  const [feedback, setFeedback] = useState<Feedback | null>(null)
+  const [isResetting, setIsResetting] = useState(false)
 
   useEffect(() => {
     if (isStaleMonthDefault(settings.start, settings.end)) {
@@ -88,8 +97,29 @@ const Analytics = () => {
     }))
   }
 
-  const resetFields = () => {
-    setSettings(DEFAULT_ANALYTICS_SETTINGS)
+  const resetFields = async () => {
+    setIsResetting(true)
+    setFeedback(null)
+
+    try {
+      const { deleted } = await resetDatabase()
+      setSettings(DEFAULT_ANALYTICS_SETTINGS)
+      setFeedback({
+        message: `Database reset. Deleted ${deleted} banana${deleted === 1 ? '' : 's'}.`,
+        type: 'success',
+      })
+      revalidator.revalidate()
+    } catch (error: unknown) {
+      setFeedback({
+        message:
+          error instanceof Error
+            ? error.message
+            : 'The database reset request failed.',
+        type: 'error',
+      })
+    } finally {
+      setIsResetting(false)
+    }
   }
 
   return (
@@ -227,12 +257,18 @@ const Analytics = () => {
       />
 
       <div>
+        {feedback ? (
+          <div className={`alert alert-${feedback.type}`}>
+            {feedback.message}
+          </div>
+        ) : null}
         <button
           className="btn btn-secondary"
+          disabled={isResetting}
           type="button"
           onClick={resetFields}
         >
-          Reset All Fields
+          {isResetting ? 'Resetting…' : 'Reset All Fields'}
         </button>
       </div>
     </main>

--- a/src/__tests__/Analytics.test.tsx
+++ b/src/__tests__/Analytics.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { MemoryRouter, useLoaderData } from 'react-router'
+import { MemoryRouter, useLoaderData, useRevalidator } from 'react-router'
 
 import Analytics from '../Analytics'
 import type { Banana } from '../types'
@@ -10,10 +10,13 @@ vi.mock('react-router', async (importOriginal) => {
   return {
     ...actual,
     useLoaderData: vi.fn(),
+    useRevalidator: vi.fn(),
   }
 })
 
 const mockedUseLoaderData = vi.mocked(useLoaderData)
+const mockedUseRevalidator = vi.mocked(useRevalidator)
+const revalidate = vi.fn()
 
 const ANALYTICS_DB: Banana[] = [
   {
@@ -32,9 +35,14 @@ describe('Analytics', () => {
   beforeEach(() => {
     window.localStorage.clear()
     mockedUseLoaderData.mockReturnValue(ANALYTICS_DB)
+    mockedUseRevalidator.mockReturnValue({
+      revalidate,
+      state: 'idle',
+    })
   })
 
   afterEach(() => {
+    vi.unstubAllGlobals()
     vi.clearAllMocks()
   })
 
@@ -161,7 +169,9 @@ describe('Analytics', () => {
       )
 
       expect(
-        await screen.findByText(/no bananas fall inside the selected date range/i)
+        await screen.findByText(
+          /no bananas fall inside the selected date range/i
+        )
       ).toBeInTheDocument()
     } finally {
       vi.useRealTimers()
@@ -200,5 +210,35 @@ describe('Analytics', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  test('resets the database and refreshes analytics data', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      json: async () => ({ deleted: 2 }),
+      ok: true,
+      status: 200,
+    })
+    vi.stubGlobal('fetch', fetch)
+
+    render(
+      <MemoryRouter>
+        <Analytics />
+      </MemoryRouter>
+    )
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /reset all fields/i })
+    )
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:8080/api/database',
+      expect.objectContaining({
+        method: 'DELETE',
+      })
+    )
+    expect(
+      await screen.findByText(/database reset\. deleted 2 bananas\./i)
+    ).toBeInTheDocument()
+    expect(revalidate).toHaveBeenCalled()
   })
 })

--- a/src/api/bananas.ts
+++ b/src/api/bananas.ts
@@ -49,3 +49,8 @@ export const sellBananas = (payload: { number: number; sellDate: string }) =>
     body: JSON.stringify(payload),
     method: 'POST',
   })
+
+export const resetDatabase = () =>
+  request<{ deleted: number }>('/api/database', {
+    method: 'DELETE',
+  })


### PR DESCRIPTION
## Summary
- wire the Analytics reset button to the backend DELETE /api/database endpoint
- show reset progress, success/error feedback, and refresh route loader data after deletion
- cover the reset request and revalidation behavior in the Analytics test

## Validation
- bun run test
- bun run lint
- bun run typecheck
- bun run format:check
- bun run build